### PR TITLE
Enable reference caching for classes which are not visible to the classloader

### DIFF
--- a/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
+++ b/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
@@ -101,7 +101,9 @@ public final class JCodeModel {
     /** All JReferencedClasses are pooled here. */
     private final HashMap<Class<?>,JReferencedClass> refClasses = new HashMap<Class<?>,JReferencedClass>();
 
-    
+    /** All JDirectClass are pooled here. */
+    private final Map<String,JDirectClass> refDirectClasses = new HashMap<String,JDirectClass>();
+
     /** Obtains a reference to the special "null" type. */
     public final JNullType NULL = new JNullType(this);
     // primitive types 
@@ -382,7 +384,12 @@ public final class JCodeModel {
         }
 
         // assume it's not visible to us.
-        return new JDirectClass(this,fullyQualifiedClassName);
+        JDirectClass jdrc = refDirectClasses.get(fullyQualifiedClassName);
+        if (jdrc == null) {
+        	jdrc = new JDirectClass(this,fullyQualifiedClassName);
+        	refDirectClasses.put(fullyQualifiedClassName, jdrc);
+        }
+        return jdrc;
     }
 
     /**

--- a/codemodel/src/test/java/com/sun/codemodel/tests/JDirectClassRefTest.java
+++ b/codemodel/src/test/java/com/sun/codemodel/tests/JDirectClassRefTest.java
@@ -1,0 +1,18 @@
+package com.sun.codemodel.tests;
+
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+
+public class JDirectClassRefTest {
+
+	@Test
+	public void testDirectClassRef() throws JClassAlreadyExistsException {
+		final JCodeModel codeModel = new JCodeModel();
+
+		assertSame("Should be same JClass", codeModel.ref("org.test.ClassNotOnClasspath"), codeModel.ref("org.test.ClassNotOnClasspath"));
+	}
+}


### PR DESCRIPTION
Enable reference caching for classes which are not visible to the classloader

Otherwise, when using such a class multiple times within the same
JClass, that very same class is not identified as the same when building
the model in the 'collecting phase'. That causes JFormatter to think
that those classes collide because having the same name, although being
the very same class. As a consequence, no import directive is created
for that class but referenced the fully qualified way instead.

![example](https://cloud.githubusercontent.com/assets/7974299/7248905/d5c7c062-e816-11e4-9918-d6872a3f78ff.png)

